### PR TITLE
Custom LogMessage and printOnConsole options

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ Below you can find an example of how to use vuejs-logger :
 | showMethodName | false | Boolean | false       | If true, the method name of the parent function will be shown in the console. |
 | separator | false | String | ' l '       | The seperator between parts of the output ( see [screenshot](#screenshot). |
 | showConsoleColors | false | Boolean | false       | If true, enables console.warn, console.fatal, console.error for corresponding loglevels. |
+| printLogOnConsole | false | Boolean | true       | If true, errors will be printed on console. (best used together with customPrintLogMessage) |
+| customPrintLogMessage | false | Function | null       | You can define a custom PrintLogMessage function, so you can send logs to backend. Function params: (logLevel: string, logMessage: string, showConsoleColors: boolean, formattedArguments: any) |
 
 #### Code example
 
@@ -107,7 +109,23 @@ function externalFunction() {
    Vue.$log.debug('log from function outside component.');
 }
 ```
-
+##### Example of 'customPrintLogMessage' 
+```js
+const options = {
+    isEnabled: true,
+    logLevel : isProduction ? 'error' : 'debug',
+    stringifyArguments : false,
+    showLogLevel : true,
+    showMethodName : true,
+    separator: '|',
+    showConsoleColors: true,
+    printLogOnConsole: false, // will just send messages to the server
+    customPrintLogMessage: function (logLevel, logMessage, showConsoleColors, formattedArguments) {
+        // send to server
+        // axios.post('/server/url', {logLevel: logLevel, logMessage: logMessage, args: formattedArguments});    
+    }
+};
+```
 
 #### Screenshot
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "typescript": "2.9.2",
     "chai": "4.1.2",
     "vue": "2.5.16",
-    "codecov": "3.0.4"
+    "codecov": "3.0.4",
+    "chai-spies": "^1.0.0"
   },
   "dependencies": {
     "es6-object-assign": "1.1.0"

--- a/src/vue-logger/interfaces/logger-options.ts
+++ b/src/vue-logger/interfaces/logger-options.ts
@@ -8,4 +8,6 @@ export interface ILoggerOptions {
     showLogLevel: boolean;
     showMethodName: boolean;
     stringifyArguments: boolean;
+    printLogOnConsole: boolean;
+    customPrintLogMessage: (logLevel: string, logMessage: string, showConsoleColors: boolean, formattedArguments: any) => void;
 }

--- a/src/vue-logger/vue-logger.ts
+++ b/src/vue-logger/vue-logger.ts
@@ -37,6 +37,12 @@ class VueLogger implements ILogger {
         if (typeof options.isEnabled !== "boolean") {
             return false;
         }
+        if (options.printLogOnConsole && (typeof options.printLogOnConsole !== "boolean")) {
+            return false;
+        }
+        if (options.customPrintLogMessage && (typeof options.customPrintLogMessage !== "function")) {
+            return false;
+        }
         return !(options.showMethodName && typeof options.showMethodName !== "boolean");
     }
 
@@ -72,7 +78,12 @@ class VueLogger implements ILogger {
                         const logLevelPrefix = options.showLogLevel ? logLevel + ` ${options.separator} ` : "";
                         const formattedArguments = options.stringifyArguments ? args.map((a) => JSON.stringify(a)) : args;
                         const logMessage = `${logLevelPrefix} ${methodNamePrefix}`;
-                        this.printLogMessage(logLevel, logMessage, options.showConsoleColors, formattedArguments);
+                        if (options.customPrintLogMessage) {
+                            options.customPrintLogMessage(logLevel, logMessage, options.showConsoleColors, formattedArguments);
+                        }
+                        if (options.printLogOnConsole) {
+                            this.printLogMessage(logLevel, logMessage, options.showConsoleColors, formattedArguments);
+                        }
                         return `${logMessage} ${formattedArguments.toString()}`;
                     };
                 } else {
@@ -100,6 +111,8 @@ class VueLogger implements ILogger {
             showLogLevel: false,
             showMethodName: false,
             stringifyArguments: false,
+            printLogOnConsole: true,
+            customPrintLogMessage: null
         };
     }
 }

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -19,6 +19,20 @@ describe("isValidOptions()", () => {
         strictEqual(input, true);
     });
 
+    test("isValidOptions() should pass with correct customPrintLogMessage.", () => {
+        const func:(logLevel: string, logMessage: string, showConsoleColors: boolean, formattedArguments: any) => void = function testFunction (a:string, b:string, c:boolean, d:any) { return; };
+        strictEqual(VueLogger.isValidOptions({
+            isEnabled: true,
+            logLevel: "debug",
+            stringifyArguments: false,
+            showLogLevel: false,
+            showMethodName: true,
+            separator: "|",
+            showConsoleColors: false,
+            customPrintLogMessage: func,
+        } as any, logLevels), true);
+    });
+
     test("isValidOptions() should fail with incorrect options.", () => {
 
         strictEqual(VueLogger.isValidOptions({
@@ -100,6 +114,8 @@ describe("isValidOptions()", () => {
             showMethodName: false,
             separator: "|",
             showConsoleColors: false,
+            printLogOnConsole: true,
+            customPrintLogMessage: null
         } as any, logLevels), true);
 
         strictEqual(VueLogger.isValidOptions({
@@ -130,6 +146,18 @@ describe("isValidOptions()", () => {
             showMethodName: false,
             separator: "|",
             showConsoleColors: false,
+        } as any, logLevels), false);
+
+        strictEqual(VueLogger.isValidOptions({
+            logLevel: "debug",
+            isEnabled: true,
+            printLogOnConsole: 'false'
+        } as any, logLevels), false);
+
+        strictEqual(VueLogger.isValidOptions({
+            logLevel: "debug",
+            isEnabled: true,
+            customPrintLogMessage: 'non function'
         } as any, logLevels), false);
     });
 });

--- a/tests/install.test.ts
+++ b/tests/install.test.ts
@@ -17,6 +17,8 @@ describe("vue-logger.ts", () => {
             showConsoleColors: true,
             showLogLevel: false,
             showMethodName: false,
+            printLogOnConsole: true,
+            customPrintLogMessage: null
         };
         Vue.use(VueLogger, options);
         expect(Vue.$log).to.be.a("object");

--- a/tests/output-no-console.test.ts
+++ b/tests/output-no-console.test.ts
@@ -10,14 +10,13 @@ chai.use(spies);
 const expect = chai.expect;
 const sandbox = chai.spy.sandbox();
 
-
-describe("output", () => {
+describe("output-no-console", () => {
 
     afterEach(() => {
         sandbox.restore(); // restores original methods
     });
 
-    test("Should instantiate log functions and be reachable from external functions.", (done) => {
+    test("Should not show console messages with printLogOnConsole equals to false.", (done) => {
         sandbox.on(console, ['log', 'warn', 'error']);
 
         const options = {
@@ -28,22 +27,19 @@ describe("output", () => {
             showMethodName: true,
             separator: "|",
             showConsoleColors: false,
+            printLogOnConsole: false
         } as ILoggerOptions;
 
         Vue.use(VueLogger, options);
         const App = new Vue({
             created() {
                 this.foo();
-                expect(console.log).to.have.been.called();
+                expect(console.log).to.have.not.been.called();
                 done();
             },
             methods: {
                 foo() {
                     expect(Vue.$log.fatal("test")).to.exist;
-                    expect(Vue.$log.error("error")).to.exist;
-                    expect(Vue.$log.warn("warn")).to.exist;
-                    expect(Vue.$log.info("info")).to.exist;
-                    expect(Vue.$log.debug("debug")).to.exist;
                     externalFunction();
                 },
             },
@@ -51,7 +47,6 @@ describe("output", () => {
 
         function externalFunction(): void {
             expect(Vue.$log.fatal("test")).to.exist;
-            expect(Vue.$log.fatal("test")).to.contains("externalFunction");
         }
     });
 });


### PR DESCRIPTION
The idea here is to implement a way to post the logger message on other places, instead of just console.
So I created two new options:
- customPrintLogMessage: function
- printLogOnConsole: boolean

Had problems with chai and jest... couldn't figure it out how to create two Vue.use on the same test file... so I created two new test files for this.