### PR TITLE
Update index.d.ts

### DIFF
--- a/src/lib/types/index.d.ts
+++ b/src/lib/types/index.d.ts
@@ -5,6 +5,10 @@ import Vue = require('vue');
 
 import * as VueLogger from '../../index';
 
+import { PluginFunction } from "vue";
+
+export const install: PluginFunction<{}>;
+
 export interface Log {
     debug(...args: any[]): void;
 


### PR DESCRIPTION
Added plugin Install const to fix the following issue 

38:9 No overload matches this call.
  Overload 1 of 2, '(plugin: PluginObject<{ logLevel: string; stringifyArguments: boolean; showLogLevel: boolean; showMethodName: boolean; separator: string; showConsoleColors: boolean; }> | PluginFunction<{ logLevel: string; ... 4 more ...; showConsoleColors: boo
lean; }>, options?: { ...; }): VueConstructor<...>', gave the following error.
    Argument of type 'typeof import("D:/Development/patworld/src/PatentSeekers.SearchApplication.SearchSpa/node_modules/vuejs-logger/dist/index")' is not assignable to parameter of type 'PluginObject<{ logLevel: string; stringifyArguments: boolean; showLogLevel: b
oolean; showMethodName: boolean; separator: string; showConsoleColors: boolean; }> | PluginFunction<{ logLevel: string; ... 4 more ...; showConsoleColors: boolean; }>'.
      Property 'install' is missing in type 'typeof import("D:/Development/patworld/src/PatentSeekers.SearchApplication.SearchSpa/node_modules/vuejs-logger/dist/index")' but required in type 'PluginObject<{ logLevel: string; stringifyArguments: boolean; showLogLev
el: boolean; showMethodName: boolean; separator: string; showConsoleColors: boolean; }>'.
  Overload 2 of 2, '(plugin: PluginObject<any> | PluginFunction<any>, ...options: any[]): VueConstructor<Vue>', gave the following error.
    Argument of type 'typeof import("D:/Development/patworld/src/PatentSeekers.SearchApplication.SearchSpa/node_modules/vuejs-logger/dist/index")' is not assignable to parameter of type 'PluginObject<any> | PluginFunction<any>'.
      Property 'install' is missing in type 'typeof import("D:/Development/patworld/src/PatentSeekers.SearchApplication.SearchSpa/node_modules/vuejs-logger/dist/index")' but required in type 'PluginObject<any>'.