### PR TITLE
Log formatting with a template literal

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,15 +55,18 @@ Below you can find an example of how to use vuejs-logger :
 
 #### Properties
 
+<style>
+table td:first-child > code {
+  white-space: nowrap;
+}
+</style>
 | Name      | Required | Type          | Default     | Description |
 | ---       | ---      | ---           | ---         | ---         |
-| isEnabled      | false  | Boolean |  true            | Enables the vuejs-logger plugin, useful toggle for production/development. |
-| logLevel     | false | String | 'debug'           | Choose between ['debug', 'info', 'warn', 'error', 'fatal']. Read [production tips](#production-tips). |
-| stringifyArguments | false | Boolean          | false       | If true, all input will go through JSON.stringify(). Useful when printing reactive properties.|
-| showLogLevel  | false | Boolean          | false       | If true, the loglevel will be shown. |
-| showMethodName | false | Boolean | false       | If true, the method name of the parent function will be shown in the console. |
-| separator | false | String | ' l '       | The seperator between parts of the output ( see [screenshot](#screenshot). |
-| showConsoleColors | false | Boolean | false       | If true, enables console.warn, console.fatal, console.error for corresponding loglevels. |
+| isEnabled      | false  | Boolean |  `true `           | Enables the vuejs-logger plugin, useful toggle for production/development. |
+| logLevel     | false | String | `"debug"`           | Choose between ['debug', 'info', 'warn', 'error', 'fatal']. Read [production tips](#production-tips). |
+| stringifyArguments | false | Boolean          | `false`       | If true, all input will go through JSON.stringify(). Useful when printing reactive properties.|
+| showConsoleColors | false | Boolean | `false`       | If true, enables console.warn, console.fatal, console.error for corresponding loglevels. |
+| format | false | String | <pre lang="js">"${message} ${args.join(' \| ')}"</pre> | Log message format template, using the template string syntax without backticks. The arguments `message`, `methodName`, `level` and `args` can be used. |
 
 #### Code example
 
@@ -75,10 +78,8 @@ const options = {
     isEnabled: true,
     logLevel : isProduction ? 'error' : 'debug',
     stringifyArguments : false,
-    showLogLevel : true,
-    showMethodName : true,
-    separator: '|',
-    showConsoleColors: true
+    showConsoleColors: true,
+    format: "${logLevel} | ${methodName} | ${message} ${args.join(' ')})",
 };
 
 Vue.use(VueLogger, options);

--- a/src/interfaces/logger-format-params.ts
+++ b/src/interfaces/logger-format-params.ts
@@ -1,0 +1,9 @@
+import {LogLevels} from "../enum/log-levels";
+
+
+export interface ILoggerFormatParams {
+    message: string;
+    methodName: string;
+    level: LogLevels;
+    args: any[];
+}

--- a/src/interfaces/logger-options.ts
+++ b/src/interfaces/logger-options.ts
@@ -3,9 +3,7 @@ import {LogLevels} from "../enum/log-levels";
 export interface ILoggerOptions {
     isEnabled: boolean;
     logLevel: LogLevels;
-    separator: string;
     showConsoleColors: boolean;
-    showLogLevel: boolean;
-    showMethodName: boolean;
     stringifyArguments: boolean;
+    format: string;
 }

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -11,10 +11,8 @@ describe("isValidOptions()", () => {
             isEnabled: true,
             logLevel: "debug",
             stringifyArguments: false,
-            showLogLevel: false,
-            showMethodName: true,
-            separator: "|",
             showConsoleColors: false,
+            format: "${methodName} ${message} ${args.join(' | ')}",
         } as any, logLevels);
         strictEqual(input, true);
     });
@@ -25,60 +23,32 @@ describe("isValidOptions()", () => {
             isEnabled: true,
             logLevel: "debug",
             stringifyArguments: false,
-            showLogLevel: false,
-            showMethodName: true,
-            separator: "|||||",
-            showConsoleColors: false,
-        } as any, logLevels), false);
-
-        strictEqual(VueLogger.isValidOptions({
-            isEnabled: true,
-            logLevel: "debug",
-            stringifyArguments: false,
-            showLogLevel: false,
-            showMethodName: true,
-            separator: "|",
             showConsoleColors: "FOO",
+            format: "${message} ${args.join(' | ')}",
         } as any, logLevels), false);
 
         strictEqual(VueLogger.isValidOptions({
             isEnabled: true,
             logLevel: "debug",
             stringifyArguments: false,
-            showLogLevel: false,
-            showMethodName: "TEST",
-            separator: "|",
             showConsoleColors: false,
+            format: 6,
         } as any, logLevels), false);
 
         strictEqual(VueLogger.isValidOptions({
             isEnabled: true,
             logLevel: "debug",
             stringifyArguments: "TEST",
-            showLogLevel: false,
-            showMethodName: false,
-            separator: "|",
             showConsoleColors: false,
-        } as any, logLevels), false);
-
-        strictEqual(VueLogger.isValidOptions({
-            isEnabled: true,
-            logLevel: "debug",
-            stringifyArguments: false,
-            showLogLevel: "TEST",
-            showMethodName: false,
-            separator: "|",
-            showConsoleColors: false,
+            format: "${message} ${args.join(' | ')}",
         } as any, logLevels), false);
 
         strictEqual(VueLogger.isValidOptions({
             isEnabled: true,
             logLevel: "TEST",
             stringifyArguments: false,
-            showLogLevel: false,
-            showMethodName: false,
-            separator: "|",
             showConsoleColors: false,
+            format: "${message} ${args.join(' | ')}",
         } as any, logLevels), false);
 
         strictEqual(VueLogger.isValidOptions({
@@ -87,28 +57,9 @@ describe("isValidOptions()", () => {
         } as any, logLevels), true);
 
         strictEqual(VueLogger.isValidOptions({
-            isEnabled: "",
-            logLevel: "debug",
-            separator: "1234",
-        } as any, logLevels), false);
-
-        strictEqual(VueLogger.isValidOptions({
             isEnabled: true,
             logLevel: "debug",
             stringifyArguments: false,
-            showLogLevel: false,
-            showMethodName: false,
-            separator: "|",
-            showConsoleColors: false,
-        } as any, logLevels), true);
-
-        strictEqual(VueLogger.isValidOptions({
-            isEnabled: false,
-            logLevel: "debug",
-            stringifyArguments: false,
-            showLogLevel: false,
-            showMethodName: false,
-            separator: "|",
             showConsoleColors: false,
         } as any, logLevels), true);
 
@@ -116,20 +67,16 @@ describe("isValidOptions()", () => {
             isEnabled: "",
             logLevel: "debug",
             stringifyArguments: false,
-            showLogLevel: false,
-            showMethodName: false,
-            separator: "|",
             showConsoleColors: false,
+            format: "${message} ${args.join(' | ')}",
         } as any, logLevels), false);
 
         strictEqual(VueLogger.isValidOptions({
             isEnabled: null,
             logLevel: "debug",
             stringifyArguments: false,
-            showLogLevel: false,
-            showMethodName: false,
-            separator: "|",
             showConsoleColors: false,
+            format: "${message} ${args.join(' | ')}",
         } as any, logLevels), false);
     });
 });

--- a/tests/install.test.ts
+++ b/tests/install.test.ts
@@ -12,11 +12,9 @@ describe("vue-logger.ts", () => {
         const options: ILoggerOptions = {
             isEnabled: true,
             logLevel: LogLevels.FATAL,
-            separator: "|",
             stringifyArguments: false,
             showConsoleColors: true,
-            showLogLevel: false,
-            showMethodName: false,
+            format: "${message} ${args.join(' | ')}",
         };
         Vue.use(VueLogger, options);
         expect(Vue.$log).to.be.a("object");
@@ -31,11 +29,9 @@ describe("vue-logger.ts", () => {
         const options: any = {
             isEnabled: true,
             logLevel: LogLevels.DEBUG,
-            separator: "|",
             stringifyArguments: false,
             showConsoleColors: true,
-            showLogLevel: false,
-            showMethodName: "wrong value for test.",
+            format: true,
         };
         expect(() => {
             VueLogger.install(Vue, options);

--- a/tests/output.test.ts
+++ b/tests/output.test.ts
@@ -12,10 +12,8 @@ describe("output", () => {
             isEnabled: true,
             logLevel: LogLevels.DEBUG,
             stringifyArguments: false,
-            showLogLevel: false,
-            showMethodName: true,
-            separator: "|",
             showConsoleColors: false,
+            format: "${methodName} ${message} ${args.join(' | ')}",
         } as ILoggerOptions;
 
         Vue.use(VueLogger, options);


### PR DESCRIPTION
This `format` option replaces the `showLogLevel`, `showMethodName` and `separator` options, and allows for way more formatting flexibility.