### PR TITLE
Fix : Vue3 Compatibility issue - Vue.prototype

### DIFF
--- a/src/vue-logger.ts
+++ b/src/vue-logger.ts
@@ -12,7 +12,12 @@ class VueLogger implements ILogger {
 
         if (this.isValidOptions(options, this.logLevels)) {
             Vue.$log = this.initLoggerInstance(options, this.logLevels);
-            Vue.prototype.$log = Vue.$log;
+            
+            /*
+            ** Vue3 Compatibility Issue
+            */ 
+            // Vue.prototype.$log = Vue.$log;
+        
         } else {
             throw new Error(this.errorMessage);
         }


### PR DESCRIPTION
Fixed the following : 
Installing the vuejs-logger plugin using `app.use(VueLogger, options)` does not work. 
The error is `TypeError: Vue.prototype is undefined`
Stacktrace extract : `vue-logger.js:20` 